### PR TITLE
Adds `PhysicalVolume.open` and `.size` to open the underlying physical device

### DIFF
--- a/dissect/volume/lvm/metadata.py
+++ b/dissect/volume/lvm/metadata.py
@@ -144,7 +144,7 @@ class PhysicalVolume(MetaBase):
         #   https://github.com/lvmteam/lvm2/blob/6e208b81ec587434097de3207fbd1ecd7a0afb8c/lib/display/display.c#L291
         if self.dev_size:
             return self.dev_size * self.vg.extent_size
-        # The size of the stripes on this device + the offset where it starts
+        # The size of the stripes on this device + size of the metadata
         return (self.pe_start + self.pe_count * self.vg.extent_size) * SECTOR_SIZE
 
     def _from_dict(self, obj: dict, name: str | None = None, parent: MetaBase | None = None) -> None:

--- a/dissect/volume/lvm/metadata.py
+++ b/dissect/volume/lvm/metadata.py
@@ -85,7 +85,7 @@ class VolumeGroup(MetaBase):
 
     def attach(self, devices: dict[str, LVM2Device]) -> None:
         for pv in self.physical_volumes.values():
-            pv._dev = devices.get(pv.id.replace("-", ""))
+            pv.dev = devices.get(pv.id.replace("-", ""))
 
     def _from_dict(self, obj: dict, name: str | None = None, parent: MetaBase | None = None) -> None:
         super()._from_dict(obj, name=name, parent=parent)
@@ -130,6 +130,23 @@ class PhysicalVolume(MetaBase):
     @property
     def dev(self) -> LVM2Device | None:
         return self._dev
+
+    @dev.setter
+    def dev(self, device: LVM2Device | None) -> None:
+        if not device:
+            return
+        # Correct the size of the LVM2 device if the size of the PhysicalVolume exceeds it
+        # This is because device_size of LVM2 can be overwritten if it is part of a VolumeGroup according to:
+        #   https://github.com/lvmteam/lvm2/blob/6e208b81ec587434097de3207fbd1ecd7a0afb8c/lib/format_text/layout.h#L44
+
+        # This size is also displayed when showing physical device information with pvdisplay:
+        #   https://github.com/lvmteam/lvm2/blob/6e208b81ec587434097de3207fbd1ecd7a0afb8c/lib/display/display.c#L291
+        if self.dev_size:
+            device.size = max(self.dev_size * self.vg.extent_size, device.size)
+        else:
+            device.size = max(self.pe_start + (self.pe_count * self.vg.extent_size * SECTOR_SIZE), device.size)
+
+        self._dev = device
 
     def _from_dict(self, obj: dict, name: str | None = None, parent: MetaBase | None = None) -> None:
         super()._from_dict(obj, name=name, parent=parent)

--- a/dissect/volume/lvm/metadata.py
+++ b/dissect/volume/lvm/metadata.py
@@ -156,7 +156,10 @@ class PhysicalVolume(MetaBase):
         self._volume_group = parent
 
     def open(self) -> BinaryIO:
-        """Opens the physical device and adjusts any sizes if required."""
+        """Opens the physical device.
+
+        Automatically uses the corect size as determined by :attr:`size`
+        """
         if self.dev is None:
             raise LVM2Error(f"Physical volume not found: {self.name} (id={self.id}, device={self.device})")
 

--- a/dissect/volume/lvm/metadata.py
+++ b/dissect/volume/lvm/metadata.py
@@ -168,11 +168,10 @@ class PhysicalVolume(MetaBase):
             return stream
 
         size = max(stream.size, self.size)
-        runlist = [
-            (area.offset // SECTOR_SIZE, (area.size or size) // SECTOR_SIZE) for area in self.dev._data_area_descriptors
-        ]
-        stream.runlist = runlist
-        stream.size = max(stream.size, self.size)
+        area = self.dev._data_area_descriptors[0]
+
+        stream.runlist = [(area.offset // SECTOR_SIZE, size // SECTOR_SIZE)]
+        stream.size = size
         return stream
 
 

--- a/dissect/volume/lvm/metadata.py
+++ b/dissect/volume/lvm/metadata.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from datetime import datetime  # noqa: TC003
 from functools import cache
 from types import UnionType
-from typing import BinaryIO, get_args, get_origin, get_type_hints
+from typing import TYPE_CHECKING, BinaryIO, get_args, get_origin, get_type_hints
 
 from dissect.util import ts
 from dissect.util.stream import MappingStream
@@ -13,6 +13,9 @@ from dissect.volume.dm.thin import ThinPool
 from dissect.volume.exceptions import LVM2Error
 from dissect.volume.lvm.c_lvm2 import SECTOR_SIZE
 from dissect.volume.lvm.physical import LVM2Device  # noqa: TC001
+
+if TYPE_CHECKING:
+    from dissect.util.stream import RunlistStream
 
 
 @dataclass(init=False)
@@ -151,6 +154,23 @@ class PhysicalVolume(MetaBase):
         super()._from_dict(obj, name=name, parent=parent)
         self._name = name
         self._volume_group = parent
+
+    def open(self) -> BinaryIO:
+        """Opens the physical device and adjusts any sizes if required."""
+        if self.dev is None:
+            raise LVM2Error(f"Physical volume not found: {self.name} (id={self.id}, device={self.device})")
+
+        stream: RunlistStream = self.dev.open()
+        if stream.size >= self.size:
+            return stream
+
+        size = max(stream.size, self.size)
+        runlist = [
+            (area.offset // SECTOR_SIZE, (area.size or size) // SECTOR_SIZE) for area in self.dev._data_area_descriptors
+        ]
+        stream.runlist = runlist
+        stream.size = max(stream.size, self.size)
+        return stream
 
 
 @dataclass(init=False)
@@ -359,11 +379,7 @@ class StripedSegment(Segment):
         offset = 0
         for pv_name, extent_offset in self.stripes:
             if pv_name not in opened_pv:
-                _pv = pv[pv_name]
-                if (pv_dev := _pv.dev) is not None:
-                    pv_fh = pv_dev.open(_pv.size)
-                else:
-                    raise LVM2Error(f"Physical volume not found: {pv_name} (id={_pv.id}, device={_pv.device})")
+                pv_fh = pv[pv_name].open()
                 opened_pv[pv_name] = pv_fh
             else:
                 pv_fh = opened_pv[pv_name]

--- a/dissect/volume/lvm/metadata.py
+++ b/dissect/volume/lvm/metadata.py
@@ -85,7 +85,7 @@ class VolumeGroup(MetaBase):
 
     def attach(self, devices: dict[str, LVM2Device]) -> None:
         for pv in self.physical_volumes.values():
-            pv.dev = devices.get(pv.id.replace("-", ""))
+            pv._dev = devices.get(pv.id.replace("-", ""))
 
     def _from_dict(self, obj: dict, name: str | None = None, parent: MetaBase | None = None) -> None:
         super()._from_dict(obj, name=name, parent=parent)
@@ -131,22 +131,19 @@ class PhysicalVolume(MetaBase):
     def dev(self) -> LVM2Device | None:
         return self._dev
 
-    @dev.setter
-    def dev(self, device: LVM2Device | None) -> None:
-        if not device:
-            return
-        # Correct the size of the LVM2 device if the size of the PhysicalVolume exceeds it
-        # This is because device_size of LVM2 can be overwritten if it is part of a VolumeGroup according to:
-        #   https://github.com/lvmteam/lvm2/blob/6e208b81ec587434097de3207fbd1ecd7a0afb8c/lib/format_text/layout.h#L44
+    @property
+    def size(self) -> int:
+        """Return the size of the physical volume in bytes.
 
+        This can sometimes be larger than what the LVM2Device dictates, but the VolumeGroup overwrites it:
+            https://github.com/lvmteam/lvm2/blob/6e208b81ec587434097de3207fbd1ecd7a0afb8c/lib/format_text/layout.h#L44
+        """
         # This size is also displayed when showing physical device information with pvdisplay:
         #   https://github.com/lvmteam/lvm2/blob/6e208b81ec587434097de3207fbd1ecd7a0afb8c/lib/display/display.c#L291
         if self.dev_size:
-            device.size = max(self.dev_size * self.vg.extent_size, device.size)
-        else:
-            device.size = max(self.pe_start + (self.pe_count * self.vg.extent_size * SECTOR_SIZE), device.size)
-
-        self._dev = device
+            return self.dev_size * self.vg.extent_size
+        # The size of the stripes on this device + the offset where it starts
+        return (self.pe_start + self.pe_count * self.vg.extent_size) * SECTOR_SIZE
 
     def _from_dict(self, obj: dict, name: str | None = None, parent: MetaBase | None = None) -> None:
         super()._from_dict(obj, name=name, parent=parent)
@@ -360,12 +357,11 @@ class StripedSegment(Segment):
         offset = 0
         for pv_name, extent_offset in self.stripes:
             if pv_name not in opened_pv:
-                if (pv_dev := pv[pv_name].dev) is not None:
-                    pv_fh = pv_dev.open()
+                _pv = pv[pv_name]
+                if (pv_dev := _pv.dev) is not None:
+                    pv_fh = pv_dev.open(_pv.size)
                 else:
-                    raise LVM2Error(
-                        f"Physical volume not found: {pv_name} (id={pv[pv_name].id}, device={pv[pv_name].device})"
-                    )
+                    raise LVM2Error(f"Physical volume not found: {pv_name} (id={_pv.id}, device={_pv.device})")
                 opened_pv[pv_name] = pv_fh
             else:
                 pv_fh = opened_pv[pv_name]

--- a/dissect/volume/lvm/metadata.py
+++ b/dissect/volume/lvm/metadata.py
@@ -135,8 +135,10 @@ class PhysicalVolume(MetaBase):
     def size(self) -> int:
         """Return the size of the physical volume in bytes.
 
-        This can sometimes be larger than what the LVM2Device dictates, but the VolumeGroup overwrites it:
+        This can sometimes be larger than what the LVM2Device dictates, in which case the VolumeGroup overwrites it:
             https://github.com/lvmteam/lvm2/blob/6e208b81ec587434097de3207fbd1ecd7a0afb8c/lib/format_text/layout.h#L44
+
+        From the code, this is also the value the pvck tool uses to update pv_header.device_size_xl.
         """
         # This size is also displayed when showing physical device information with pvdisplay:
         #   https://github.com/lvmteam/lvm2/blob/6e208b81ec587434097de3207fbd1ecd7a0afb8c/lib/display/display.c#L291

--- a/dissect/volume/lvm/physical.py
+++ b/dissect/volume/lvm/physical.py
@@ -88,9 +88,9 @@ class LVM2Device:
 
         return b"".join(r)
 
-    def open(self, pv_size: int = 0) -> BinaryIO:
+    def open(self, size: int | None = None) -> BinaryIO:
         # Use pv_size if the size reported by the pv_header is smaller than the one found inside the PhysicalVolume
-        size = max(pv_size, self.size)
+        size = max(size or 0, self.size)
         runlist = [
             (area.offset // SECTOR_SIZE, (area.size or size) // SECTOR_SIZE) for area in self._data_area_descriptors
         ]

--- a/dissect/volume/lvm/physical.py
+++ b/dissect/volume/lvm/physical.py
@@ -89,7 +89,7 @@ class LVM2Device:
         return b"".join(r)
 
     def open(self, pv_size: int = 0) -> BinaryIO:
-        # Use pv_size if the physical
+        # Use pv_size if the size reported by the pv_header is smaller than the one found inside the PhysicalVolume
         size = max(pv_size, self.size)
         runlist = [
             (area.offset // SECTOR_SIZE, (area.size or size) // SECTOR_SIZE) for area in self._data_area_descriptors

--- a/dissect/volume/lvm/physical.py
+++ b/dissect/volume/lvm/physical.py
@@ -88,14 +88,14 @@ class LVM2Device:
 
         return b"".join(r)
 
-    def open(self, size: int | None = None) -> BinaryIO:
+    def open(self) -> BinaryIO:
         # Use pv_size if the size reported by the pv_header is smaller than the one found inside the PhysicalVolume
-        size = max(size or 0, self.size)
         runlist = [
-            (area.offset // SECTOR_SIZE, (area.size or size) // SECTOR_SIZE) for area in self._data_area_descriptors
+            (area.offset // SECTOR_SIZE, (area.size or self.size) // SECTOR_SIZE)
+            for area in self._data_area_descriptors
         ]
 
-        return RunlistStream(self.fh, runlist, size, SECTOR_SIZE)
+        return RunlistStream(self.fh, runlist, self.size, SECTOR_SIZE)
 
 
 def _read_descriptors(

--- a/dissect/volume/lvm/physical.py
+++ b/dissect/volume/lvm/physical.py
@@ -30,6 +30,7 @@ class LVM2Device:
             raise LVM2Error("Can't find physical volume label header")
 
         fh.seek(self.label_offset + self.label.offset)
+
         self.header = c_lvm.pv_header(fh)
         self.id = self.header.pv_uuid.decode()
         self.size = self.header.device_size
@@ -87,13 +88,14 @@ class LVM2Device:
 
         return b"".join(r)
 
-    def open(self) -> BinaryIO:
+    def open(self, pv_size: int = 0) -> BinaryIO:
+        # Use pv_size if the physical
+        size = max(pv_size, self.size)
         runlist = [
-            (area.offset // SECTOR_SIZE, (area.size or self.size) // SECTOR_SIZE)
-            for area in self._data_area_descriptors
+            (area.offset // SECTOR_SIZE, (area.size or size) // SECTOR_SIZE) for area in self._data_area_descriptors
         ]
 
-        return RunlistStream(self.fh, runlist, self.size, SECTOR_SIZE)
+        return RunlistStream(self.fh, runlist, size, SECTOR_SIZE)
 
 
 def _read_descriptors(

--- a/dissect/volume/lvm/physical.py
+++ b/dissect/volume/lvm/physical.py
@@ -89,7 +89,6 @@ class LVM2Device:
         return b"".join(r)
 
     def open(self) -> BinaryIO:
-        # Use pv_size if the size reported by the pv_header is smaller than the one found inside the PhysicalVolume
         runlist = [
             (area.offset // SECTOR_SIZE, (area.size or self.size) // SECTOR_SIZE)
             for area in self._data_area_descriptors

--- a/dissect/volume/lvm/physical.py
+++ b/dissect/volume/lvm/physical.py
@@ -36,6 +36,11 @@ class LVM2Device:
         self.size = self.header.device_size
 
         self._data_area_descriptors = _read_descriptors(fh, c_lvm.disk_locn)
+
+        if len(self._data_area_descriptors) != 1:
+            # According to the LVM2 code, there should only be 1 data area descriptor for each Physical Volume
+            raise RuntimeError(f"There should be 1 data area descriptor, found {len(self._data_area_descriptors)}")
+
         self._metadata_area_descriptors = _read_descriptors(fh, c_lvm.disk_locn)
 
         self._metadata_areas = []
@@ -89,11 +94,10 @@ class LVM2Device:
         return b"".join(r)
 
     def open(self) -> BinaryIO:
-        runlist = [
-            (area.offset // SECTOR_SIZE, (area.size or self.size) // SECTOR_SIZE)
-            for area in self._data_area_descriptors
-        ]
-
+        # Only accounts for one data area descriptor
+        # When multiple descriptors get allowed in the future, this code should be adjusted to reflect that
+        area = self._data_area_descriptors[0]
+        runlist = [(area.offset // SECTOR_SIZE, self.size // SECTOR_SIZE)]
         return RunlistStream(self.fh, runlist, self.size, SECTOR_SIZE)
 
 

--- a/tests/_data/generate-lvm.sh
+++ b/tests/_data/generate-lvm.sh
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4fb06a35a6a255aeead631ab76ce3cacd6dec35a6f3974e7505be3fa6cd547bb
-size 842

--- a/tests/_data/generate-lvm.sh
+++ b/tests/_data/generate-lvm.sh
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4fb06a35a6a255aeead631ab76ce3cacd6dec35a6f3974e7505be3fa6cd547bb
+size 842

--- a/tests/_data/lvm/lvm-inconsistent-sizes.bin.gz
+++ b/tests/_data/lvm/lvm-inconsistent-sizes.bin.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4773467385d61c51980dbfcf951fbfdc3cddf68f537cde7e065395be503efa6b
+size 16403

--- a/tests/_data/lvm/lvm-inconsistent-sizes.bin.gz
+++ b/tests/_data/lvm/lvm-inconsistent-sizes.bin.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4773467385d61c51980dbfcf951fbfdc3cddf68f537cde7e065395be503efa6b
-size 16403
+oid sha256:1bfc36f419bc5808f99fc2529ec24d381704fb77dae7b6c65a3eaf8c8f0e18e3
+size 11019

--- a/tests/_tools/lvm/generate.sh
+++ b/tests/_tools/lvm/generate.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -e
+
+function _create_lvm_inconsistent_sizes {
+  local filename="$1"
+  dd if=/dev/zero of="$filename" bs=1M count=8
+
+  local lo=$(sudo losetup --partscan --show --find "$filename")
+  local uid=$(id -u)
+
+  sudo pvcreate "$lo"
+  sudo vgcreate vghelp "$lo"
+  sudo lvcreate -l 100%FREE -n lv vghelp
+  sudo mkfs.ext4 /dev/vghelp/lv
+  sudo mount /dev/vghelp/lv /mnt/tmp-lvm --mkdir
+  sudo chmod -R o+rw /mnt/tmp-lvm
+  fallocate -l "2448KiB" /mnt/tmp-lvm/large-file
+  echo "A small file at the end of the disk" > /mnt/tmp-lvm/small-file
+
+  sudo umount /mnt/tmp-lvm
+  sudo lvchange -an vghelp/lv
+  sudo vgchange -an vghelp
+  sudo losetup -d "$lo"
+  # Updae the size at this offset
+  printf "00000240: 0000 3000" | xxd -r - "$filename"
+  gzip "$filename"
+}
+
+
+_create_lvm_inconsistent_sizes "./lvm/lvm-inconsistent-sizes.bin"
+

--- a/tests/_tools/lvm/generate.sh
+++ b/tests/_tools/lvm/generate.sh
@@ -1,32 +1,80 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-set -e
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly TESTS_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+readonly OUT_DIR="${TESTS_ROOT}/_data/lvm"
+
+log()  { printf '[INFO] %s\n' "$*" >&2; }
+warn() { printf '[WARN] %s\n' "$*" >&2; }
+error()  { printf '[ERROR] %s\n' "$*" >&2; }
+have() { command -v "$1" >/dev/null 2>&1; }
+
+require_tools() {
+    local -a tools=(pvcreate mkfs.ext4 dd xxd)
+    local missing=0
+
+    for t in "${tools[@]}"; do
+        if ! have "$t"; then
+            error "Missing required tool: $t"
+            missing=1
+        fi
+    done
+
+    if (( missing != 0 )); then
+        error "One or more required tools are missing. Aborting."
+        exit 1
+    fi
+}
 
 function _create_lvm_inconsistent_sizes {
   local filename="$1"
-  dd if=/dev/zero of="$filename" bs=1M count=8
+  local uid=$(id -u)
+  dd if=/dev/zero of="$filename" bs=1M count=8 >&/dev/null
+  log "Created block device $filename"
 
   local lo=$(sudo losetup --partscan --show --find "$filename")
-  local uid=$(id -u)
 
-  sudo pvcreate "$lo"
-  sudo vgcreate vghelp "$lo"
-  sudo lvcreate -l 100%FREE -n lv vghelp
-  sudo mkfs.ext4 /dev/vghelp/lv
+  log "Created loopback device $lo"
+  sudo pvcreate "$lo" >/dev/null
+  sudo vgcreate vghelp "$lo" >/dev/null
+  sudo lvcreate -l 100%FREE -n lv vghelp >/dev/null
+  sudo mkfs.ext4 /dev/vghelp/lv >&/dev/null
+
+  log "Created lvm2 structure"
+
+
   sudo mount /dev/vghelp/lv /mnt/tmp-lvm --mkdir
   sudo chmod -R o+rw /mnt/tmp-lvm
   fallocate -l "2448KiB" /mnt/tmp-lvm/large-file
   echo "A small file at the end of the disk" > /mnt/tmp-lvm/small-file
 
+  log "Created files on disk"
+
+  log "Cleanup lvm devices"
   sudo umount /mnt/tmp-lvm
   sudo lvchange -an vghelp/lv
-  sudo vgchange -an vghelp
+  sudo vgchange -an vghelp >/dev/null
   sudo losetup -d "$lo"
-  # Updae the size at this offset
+
+
+  log "Update size of the pv header"
+  # Update the size at this offset
   printf "00000240: 0000 3000" | xxd -r - "$filename"
+
+  # Compress the resulting file
   gzip "$filename"
 }
 
 
-_create_lvm_inconsistent_sizes "./lvm/lvm-inconsistent-sizes.bin"
+main() {
+    require_tools
 
+    mkdir -p "${OUT_DIR}"
+
+    _create_lvm_inconsistent_sizes "${OUT_DIR}/lvm-inconsistent-sizes.bin"
+
+    log "All test cases generated under: ${OUT_DIR}"
+}
+
+main

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,6 +46,11 @@ def lvm_mirror() -> Iterator[list[BinaryIO]]:
 
 
 @pytest.fixture
+def lvm_inconsistent_sizes() -> Iterator[BinaryIO]:
+    yield from open_file_gz("_data/lvm/lvm-inconsistent-sizes.bin.gz")
+
+
+@pytest.fixture
 def mbr() -> Iterator[BinaryIO]:
     yield from open_file("_data/disk/mbr.bin")
 

--- a/tests/lvm/test_lvm.py
+++ b/tests/lvm/test_lvm.py
@@ -85,6 +85,7 @@ def test_lvm_mirror(lvm_mirror: list[BinaryIO]) -> None:
 
 
 def test_lvm_sizes_mismatch(lvm_inconsistent_sizes: BinaryIO) -> None:
+    """Test if opening the LVM2Device uses PhysicalVolume.size when LVM2Device.size < PhysicalVolume.size."""
     lvm = LVM2(lvm_inconsistent_sizes)
 
     lv = lvm.vg.logical_volumes["lv"]
@@ -111,6 +112,7 @@ def test_lvm_sizes_mismatch(lvm_inconsistent_sizes: BinaryIO) -> None:
 
 
 def test_lvm_sizes_mismatch_missing_dev_size(lvm_inconsistent_sizes: BinaryIO) -> None:
+    """Test if opening the LVM2Device uses the calculated disk size when PhysicalVolume.dev_size is missing."""
     lvm = LVM2(lvm_inconsistent_sizes)
 
     lv = lvm.vg.logical_volumes["lv"]
@@ -127,6 +129,10 @@ def test_lvm_sizes_mismatch_missing_dev_size(lvm_inconsistent_sizes: BinaryIO) -
     fh = lv.open()
     # Size of the stripe
     assert fh.size == 0x400000
+
+    segment_stream = fh._runs[0][2]
+    pv_stream = segment_stream._runs[0][2]
+    assert pv_stream.size == 0x500000
 
     fh.seek(0x3B8800)
 

--- a/tests/lvm/test_lvm.py
+++ b/tests/lvm/test_lvm.py
@@ -91,20 +91,20 @@ def test_lvm_sizes_mismatch(lvm_inconsistent_sizes: BinaryIO) -> None:
 
     # Size manually adjusted to be smaller than the actual data
     # This is the offset the data of a text file starts
-    assert next(iter(lvm.devices.values())).size == 0x39C800
+    assert next(iter(lvm.devices.values())).size == 0x300000
     physical_volume = lvm.vg.pv[0]
-    assert physical_volume.size == 0xC000000
+    assert physical_volume.size == 0x8000000
 
     fh = lv.open()
     # Size of the stripe
-    assert fh.size == 0x800000
+    assert fh.size == 0x400000
 
     segment_stream = fh._runs[0][2]
     pv_stream = segment_stream._runs[0][2]
     # Check whether the underlying pv stream size is correct (The non adjusted size)
-    assert pv_stream.size == 0xC000000
+    assert pv_stream.size == 0x8000000
 
-    fh.seek(0x39C800)
+    fh.seek(0x3B8800)
 
     expected_data = b"A small file at the end of the disk"
     assert fh.read(len(expected_data)) == expected_data
@@ -117,18 +117,18 @@ def test_lvm_sizes_mismatch_missing_dev_size(lvm_inconsistent_sizes: BinaryIO) -
 
     # Size manually adjusted to be smaller than the actual data
     # This is the offset the data of a text file starts
-    assert next(iter(lvm.devices.values())).size == 0x39C800
+    assert next(iter(lvm.devices.values())).size == 0x300000
     physical_volume = lvm.vg.pv[0]
     # physical_volume.size will calculate size based on the the data offset
     # and size of the stripes if dev_size is not defined
     physical_volume.dev_size = None
-    assert physical_volume.size == 0x900000
+    assert physical_volume.size == 0x500000
 
     fh = lv.open()
     # Size of the stripe
-    assert fh.size == 0x800000
+    assert fh.size == 0x400000
 
-    fh.seek(0x39C800)
+    fh.seek(0x3B8800)
 
     expected_data = b"A small file at the end of the disk"
     assert fh.read(len(expected_data)) == expected_data

--- a/tests/lvm/test_lvm.py
+++ b/tests/lvm/test_lvm.py
@@ -8,6 +8,7 @@ import pytest
 
 from dissect.volume.exceptions import LVM2Error
 from dissect.volume.lvm import LVM2
+from dissect.volume.lvm.c_lvm2 import c_lvm
 from dissect.volume.lvm.metadata import StripedSegment
 
 
@@ -82,6 +83,23 @@ def test_lvm_mirror(lvm_mirror: list[BinaryIO]) -> None:
     fh = lv.open()
     for i in range(1, 513):
         assert fh.read(4096) == i.to_bytes(2, "little") * 2048
+
+
+def test_lvm_multiple_data_areas() -> None:
+    """Test if LVM2 raises an Error if more than 1 data area descriptor is specified.
+
+    This test can be removed once lvm2 allows for multiple area descriptors
+    """
+    lvm_data = [
+        c_lvm.label_header(id=b"LABELONE", offset=len(c_lvm.label_header)),
+        c_lvm.pv_header(),
+        c_lvm.disk_locn(offset=1),
+        c_lvm.disk_locn(offset=2),
+        c_lvm.disk_locn(),
+    ]
+    data = io.BytesIO(b"".join(struct.dumps() for struct in lvm_data))
+    with pytest.raises(RuntimeError, match="There should be 1 data area descriptor, found 2"):
+        LVM2(data)
 
 
 def test_lvm_sizes_mismatch(lvm_inconsistent_sizes: BinaryIO) -> None:

--- a/tests/lvm/test_lvm.py
+++ b/tests/lvm/test_lvm.py
@@ -82,3 +82,53 @@ def test_lvm_mirror(lvm_mirror: list[BinaryIO]) -> None:
     fh = lv.open()
     for i in range(1, 513):
         assert fh.read(4096) == i.to_bytes(2, "little") * 2048
+
+
+def test_lvm_sizes_mismatch(lvm_inconsistent_sizes: BinaryIO) -> None:
+    lvm = LVM2(lvm_inconsistent_sizes)
+
+    lv = lvm.vg.logical_volumes["lv"]
+
+    # Size manually adjusted to be smaller than the actual data
+    # This is the offset the data of a text file starts
+    assert next(iter(lvm.devices.values())).size == 0x39C800
+    physical_volume = lvm.vg.pv[0]
+    assert physical_volume.size == 0xC000000
+
+    fh = lv.open()
+    # Size of the stripe
+    assert fh.size == 0x800000
+
+    segment_stream = fh._runs[0][2]
+    pv_stream = segment_stream._runs[0][2]
+    # Check whether the underlying pv stream size is correct (The non adjusted size)
+    assert pv_stream.size == 0xC000000
+
+    fh.seek(0x39C800)
+
+    expected_data = b"A small file at the end of the disk"
+    assert fh.read(len(expected_data)) == expected_data
+
+
+def test_lvm_sizes_mismatch_missing_dev_size(lvm_inconsistent_sizes: BinaryIO) -> None:
+    lvm = LVM2(lvm_inconsistent_sizes)
+
+    lv = lvm.vg.logical_volumes["lv"]
+
+    # Size manually adjusted to be smaller than the actual data
+    # This is the offset the data of a text file starts
+    assert next(iter(lvm.devices.values())).size == 0x39C800
+    physical_volume = lvm.vg.pv[0]
+    # physical_volume.size will calculate size based on the the data offset
+    # and size of the stripes if dev_size is not defined
+    physical_volume.dev_size = None
+    assert physical_volume.size == 0x900000
+
+    fh = lv.open()
+    # Size of the stripe
+    assert fh.size == 0x800000
+
+    fh.seek(0x39C800)
+
+    expected_data = b"A small file at the end of the disk"
+    assert fh.read(len(expected_data)) == expected_data


### PR DESCRIPTION
This seems to be the cause of https://github.com/fox-it/dissect/issues/93
Where it, assumedly, tried to read beyond the LVM2Device disk size where it could not reach.

# TODO

- [x] Generate test data that displays this behaviour
- [x] Create a test to show this behaviour is fixed

<!--
Thank you for submitting a Pull Request. Please:
* Read our commit style guide:
    Commit messages should adhere to the following points:
    * Separate subject from body with a blank line
    * Limit the subject line to 50 characters as much as possible
    * Capitalize the subject line
    * Do not end the subject line with a period
    * Use the imperative mood in the subject line
    * The verb should represent what was accomplished (Create, Add, Fix etc)
    * Wrap the body at 72 characters
    * Use the body to explain the what and why vs. the how
  For an example, look at the following link:
  https://docs.dissect.tools/en/latest/contributing/style-guide.html#example-commit-message

* Include a description of the proposed changes and how to test them.

* After creation, associate the PR with an issue, under the development section.
  Or use closing keywords in the body during creation:
  E.G:
  * close(|s|d) #<nr>
  * fix(|es|ed) #<nr>
  * resolve(|s|d) #<nr>
-->
